### PR TITLE
Add missing Blaize colors

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,8 @@ module.exports = {
         'blaize-green': '#4D9900',    // Deep, logo-matching green
         'blaize-orange': '#FF8400',   // Logo orange
         'blaize-slate': '#181c20',    // True dark slate background
+        'blaize-dark': '#232332',     // Dark card and section background
+        'blaize-yellow': '#E7F800',   // Vibrant accent yellow
       },
       dropShadow: {
         glow: '0 0 16px #4D9900cc',  // Subtle green glow


### PR DESCRIPTION
## Summary
- extend Tailwind palette with `blaize-dark` and `blaize-yellow`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687515d050b88323b35e06670f21eec2