### PR TITLE
Install lucide-react and fix tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,3 +4,16 @@ import { TextEncoder, TextDecoder } from 'util';
 // JSDOM does not provide these encoders by default
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+// Provide a basic IntersectionObserver mock for tests
+class MockIntersectionObserver {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.IntersectionObserver = MockIntersectionObserver;
+
+// JSDOM doesn't implement scrollIntoView
+window.HTMLElement.prototype.scrollIntoView = function() {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.10",
         "framer-motion": "^12.17.3",
+        "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
@@ -7078,6 +7079,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.10",
     "framer-motion": "^12.17.3",
+    "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",


### PR DESCRIPTION
## Summary
- add `lucide-react` dependency that App.jsx requires
- mock IntersectionObserver and scrollIntoView in jest setup so App can render in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687570f15ca88323a23a61150b3accd9