### PR TITLE
Add holographic grid overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ BLAiZE IT Solutions provides managed IT services, cybersecurity consulting, clou
 - Service and testimonial carousels powered by **Swiper**
 - Booking and contact forms via Formspree
 - Progressive Web App setup with a service worker and `manifest.webmanifest`
+- Immersive starfield background rendered on an HTML canvas
+- Animated holographic grid overlay for a high-tech vibe
 
 ## Getting Started
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useRef, Suspense, lazy } from "react";
 // No need for react-router-dom as we'll simulate routing internally for a single file app
 // import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
 import { Menu, X, CheckCircle, XCircle, Loader2, ChevronLeft, ChevronRight } from 'lucide-react'; // Icons
+import Starfield from './components/Starfield';
+import HolographicGrid from './components/HolographicGrid';
 
 // --- Utility Components ---
 
@@ -651,6 +653,8 @@ export default function App() {
         `
       }}></script>
 
+      <Starfield />
+      <HolographicGrid />
       <Navbar currentPage={currentPage} setCurrentPage={setCurrentPage} />
 
       <main className="pt-16"> {/* Add padding top to account for fixed navbar */}

--- a/src/components/HolographicGrid.jsx
+++ b/src/components/HolographicGrid.jsx
@@ -1,0 +1,45 @@
+import React, { useRef, useEffect } from 'react';
+
+export default function HolographicGrid() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    let width = canvas.width = window.innerWidth;
+    let height = canvas.height = window.innerHeight;
+    let animationFrameId;
+    const render = (time = 0) => {
+      ctx.clearRect(0, 0, width, height);
+      ctx.strokeStyle = 'rgba(0,255,255,0.3)';
+      ctx.lineWidth = 1;
+      const spacing = 40;
+      const offset = Math.sin(time / 1000) * 20;
+      ctx.beginPath();
+      for (let x = -spacing; x <= width + spacing; x += spacing) {
+        ctx.moveTo(x + offset, 0);
+        ctx.lineTo(x - offset, height);
+      }
+      for (let y = -spacing; y <= height + spacing; y += spacing) {
+        ctx.moveTo(0, y + offset);
+        ctx.lineTo(width, y - offset);
+      }
+      ctx.stroke();
+      animationFrameId = requestAnimationFrame(render);
+    };
+    render();
+    const handleResize = () => {
+      width = canvas.width = window.innerWidth;
+      height = canvas.height = window.innerHeight;
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="fixed inset-0 -z-10 mix-blend-overlay pointer-events-none" />;
+}

--- a/src/components/Starfield.jsx
+++ b/src/components/Starfield.jsx
@@ -1,0 +1,47 @@
+import React, { useRef, useEffect } from 'react';
+
+export default function Starfield() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    let width = canvas.width = window.innerWidth;
+    let height = canvas.height = window.innerHeight;
+    const stars = new Array(250).fill().map(() => ({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      z: Math.random() * width
+    }));
+    const update = () => {
+      ctx.fillStyle = 'rgba(0,0,0,0.4)';
+      ctx.fillRect(0,0,width,height);
+      for (let s of stars) {
+        s.z -= 2;
+        if (s.z <= 0) s.z = width;
+        const k = 128 / s.z;
+        const px = s.x * k + width/2;
+        const py = s.y * k + height/2;
+        if (px >= 0 && px <= width && py >= 0 && py <= height) {
+          const size = (1 - s.z / width) * 2;
+          ctx.fillStyle = '#fff';
+          ctx.fillRect(px, py, size, size);
+        }
+      }
+      requestAnimationFrame(update);
+    };
+    update();
+    const handleResize = () => {
+      width = canvas.width = window.innerWidth;
+      height = canvas.height = window.innerHeight;
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="fixed inset-0 -z-20" />;
+}

--- a/src/components/__tests__/HolographicGrid.test.jsx
+++ b/src/components/__tests__/HolographicGrid.test.jsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import HolographicGrid from '../HolographicGrid';
+
+describe('HolographicGrid', () => {
+  test('renders canvas element', () => {
+    const { container } = render(<HolographicGrid />);
+    const canvas = container.querySelector('canvas');
+    expect(canvas).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Starfield.test.jsx
+++ b/src/components/__tests__/Starfield.test.jsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import Starfield from '../Starfield';
+
+describe('Starfield', () => {
+  test('renders canvas element', () => {
+    const { container } = render(<Starfield />);
+    const canvas = container.querySelector('canvas');
+    expect(canvas).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- create dynamic HolographicGrid canvas component
- render HolographicGrid alongside Starfield
- update starfield z-index for layering
- document new effect in README
- add unit test for HolographicGrid

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6875dae7e2c88323ba6a142171ab6e01