### PR TITLE
Add warp tunnel backdrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ BLAiZE IT Solutions provides managed IT services, cybersecurity consulting, clou
 - Service and testimonial carousels powered by **Swiper**
 - Booking and contact forms via Formspree
 - Progressive Web App setup with a service worker and `manifest.webmanifest`
+- Immersive warp tunnel effect rendered on an HTML canvas
 
 ## Getting Started
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, Suspense, lazy } from "react";
 // No need for react-router-dom as we'll simulate routing internally for a single file app
 // import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
 import { Menu, X, CheckCircle, XCircle, Loader2, ChevronLeft, ChevronRight } from 'lucide-react'; // Icons
+import WarpTunnel from './components/WarpTunnel';
 
 // --- Utility Components ---
 
@@ -651,6 +652,7 @@ export default function App() {
         `
       }}></script>
 
+      <WarpTunnel />
       <Navbar currentPage={currentPage} setCurrentPage={setCurrentPage} />
 
       <main className="pt-16"> {/* Add padding top to account for fixed navbar */}

--- a/src/components/Starfield.jsx
+++ b/src/components/Starfield.jsx
@@ -1,0 +1,47 @@
+import React, { useRef, useEffect } from 'react';
+
+export default function Starfield() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    let width = canvas.width = window.innerWidth;
+    let height = canvas.height = window.innerHeight;
+    const stars = new Array(250).fill().map(() => ({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      z: Math.random() * width
+    }));
+    const update = () => {
+      ctx.fillStyle = 'rgba(0,0,0,0.4)';
+      ctx.fillRect(0,0,width,height);
+      for (let s of stars) {
+        s.z -= 2;
+        if (s.z <= 0) s.z = width;
+        const k = 128 / s.z;
+        const px = s.x * k + width/2;
+        const py = s.y * k + height/2;
+        if (px >= 0 && px <= width && py >= 0 && py <= height) {
+          const size = (1 - s.z / width) * 2;
+          ctx.fillStyle = '#fff';
+          ctx.fillRect(px, py, size, size);
+        }
+      }
+      requestAnimationFrame(update);
+    };
+    update();
+    const handleResize = () => {
+      width = canvas.width = window.innerWidth;
+      height = canvas.height = window.innerHeight;
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="fixed inset-0 -z-10" />;
+}

--- a/src/components/WarpTunnel.jsx
+++ b/src/components/WarpTunnel.jsx
@@ -1,0 +1,59 @@
+import React, { useRef, useEffect } from 'react';
+
+export default function WarpTunnel() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    let width = canvas.width = window.innerWidth;
+    let height = canvas.height = window.innerHeight;
+    const radiusMax = Math.min(width, height) / 2;
+    const stars = new Array(600).fill().map(() => ({
+      angle: Math.random() * Math.PI * 2,
+      radius: Math.random() * radiusMax,
+      depth: Math.random() * 400 + 100
+    }));
+    let lastTime = performance.now();
+
+    const update = (time) => {
+      const delta = time - lastTime;
+      lastTime = time;
+      ctx.fillStyle = 'rgba(0,0,20,0.6)';
+      ctx.fillRect(0, 0, width, height);
+      ctx.save();
+      ctx.translate(width / 2, height / 2);
+      for (const star of stars) {
+        star.depth -= delta * 0.2;
+        star.angle += delta * 0.0008;
+        if (star.depth <= 0) {
+          star.depth = Math.random() * 400 + 100;
+          star.radius = Math.random() * radiusMax;
+        }
+        const scale = 300 / star.depth;
+        const x = Math.cos(star.angle) * star.radius * scale;
+        const y = Math.sin(star.angle) * star.radius * scale;
+        const size = (1 - star.depth / 400) * 3;
+        const hue = 200 + (star.depth / 2);
+        ctx.fillStyle = `hsl(${hue},80%,70%)`;
+        ctx.fillRect(x, y, size, size);
+      }
+      ctx.restore();
+      requestAnimationFrame(update);
+    };
+    requestAnimationFrame(update);
+
+    const handleResize = () => {
+      width = canvas.width = window.innerWidth;
+      height = canvas.height = window.innerHeight;
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="fixed inset-0 -z-10" />;
+}

--- a/src/components/__tests__/Starfield.test.jsx
+++ b/src/components/__tests__/Starfield.test.jsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import Starfield from '../Starfield';
+
+describe('Starfield', () => {
+  test('renders canvas element', () => {
+    const { container } = render(<Starfield />);
+    const canvas = container.querySelector('canvas');
+    expect(canvas).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/WarpTunnel.test.jsx
+++ b/src/components/__tests__/WarpTunnel.test.jsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import WarpTunnel from '../WarpTunnel';
+
+describe('WarpTunnel', () => {
+  test('renders canvas element', () => {
+    const { container } = render(<WarpTunnel />);
+    const canvas = container.querySelector('canvas');
+    expect(canvas).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add WarpTunnel canvas component and render it in the app
- add WarpTunnel tests
- document new warp tunnel effect in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6875dae7e2c88323ba6a142171ab6e01