### PR TITLE
Fix missing helper in GPUComputationRenderer

### DIFF
--- a/src/components/GPUComputationRenderer.js
+++ b/src/components/GPUComputationRenderer.js
@@ -38,7 +38,11 @@ var GPUComputationRenderer = function ( sizeX, sizeY, renderer ) {
 		passThruTexture: { value: null }
 	};
 
-	function createShaderMaterial( computeFragmentShader, uniforms ) {
+        function addResolutionDefine( material ) {
+                material.defines.resolution = 'vec2( ' + sizeX.toFixed( 1 ) + ', ' + sizeY.toFixed( 1 ) + ' )';
+        }
+
+        function createShaderMaterial( computeFragmentShader, uniforms ) {
 
 		uniforms = uniforms || {};
 
@@ -50,7 +54,7 @@ var GPUComputationRenderer = function ( sizeX, sizeY, renderer ) {
 
 		} );
 
-		addResolutionDefine( material );
+                addResolutionDefine( material );
 
 		return material;
 


### PR DESCRIPTION
## Summary
- add `addResolutionDefine` helper function so shaders compile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688cf1c077b483238fa1555a27f3a01f