### PR TITLE
host logo locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 build
 .env
+
+public/logo.png

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ blaize-it/
         └── TestimonialsPage.jsx
 ```
 
-> **Note:** The site logo is loaded dynamically from `https://i.imgur.com/VHCRCEn.png` and is not bundled in this repository.
+> **Note:** The site logo is downloaded during installation and written to `public/logo.png`.
 
 ## Deployment
 A sample `vercel.json` configuration is provided for deploying to [Vercel](https://vercel.com/). The service worker enables offline caching of the main page, while the web manifest allows installation as a PWA.

--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
     <title>BLAiZE IT Solutions</title>
     <meta name="description" content="IT Solutions for Business and Home" />
 
-    <link rel="icon" type="image/png" href="https://i.imgur.com/VHCRCEn.png" />
+    <link rel="icon" type="image/png" href="/logo.png" />
 
     <meta property="og:title" content="BLAiZE IT Solutions" />
     <meta property="og:description" content="IT Solutions for Business and Home" />
-    <meta property="og:image" content="https://i.imgur.com/VHCRCEn.png" />
+    <meta property="og:image" content="/logo.png" />
     <meta property="og:url" content="https://www.blaizeit.com/" />
     <meta property="og:type" content="website" />
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest",
+    "fetch-logo": "node scripts/fetch-logo.js",
+    "postinstall": "npm run fetch-logo"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -2,16 +2,16 @@
   "name": "BLAiZE IT Solutions",
   "short_name": "BLAiZE IT",
   "icons": [
-    {
-      "src": "https://i.imgur.com/VHCRCEn.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "https://i.imgur.com/VHCRCEn.png",
-      "sizes": "512x512",
-      "type": "image/png"
-    }
+      {
+        "src": "/logo.png",
+        "sizes": "192x192",
+        "type": "image/png"
+      },
+      {
+        "src": "/logo.png",
+        "sizes": "512x512",
+        "type": "image/png"
+      }
   ],
   "start_url": "/",
   "display": "standalone",

--- a/scripts/fetch-logo.js
+++ b/scripts/fetch-logo.js
@@ -1,0 +1,11 @@
+const { execSync } = require('child_process');
+const path = require('path');
+
+const dest = path.join(__dirname, '..', 'public', 'logo.png');
+const url = 'https://i.imgur.com/VHCRCEn.png';
+
+try {
+  execSync(`curl -L ${url} -o "${dest}"`, { stdio: 'inherit' });
+} catch (err) {
+  console.error('Failed to download logo:', err);
+}

--- a/src/components/AboutSection.jsx
+++ b/src/components/AboutSection.jsx
@@ -13,7 +13,7 @@ export default function AboutSection() {
         viewport={{ once: true }}
       >
         <img
-          src="https://i.imgur.com/VHCRCEn.png"
+          src="/logo.png"
           alt="BLAiZE IT Founder"
           className="rounded-full w-52 h-52 object-contain shadow-2xl bg-white/10"
         />

--- a/src/components/AnimatedLogo.jsx
+++ b/src/components/AnimatedLogo.jsx
@@ -65,7 +65,7 @@ export default function AnimatedLogo() {
     currentMount.appendChild(renderer.domElement);
 
     const loader = new THREE.TextureLoader();
-    const texture = loader.load('https://i.imgur.com/VHCRCEn.png'); // Corrected logo from Imgur
+    const texture = loader.load('/logo.png');
 
     const geometry = new THREE.PlaneGeometry(8, 8);
     const material = new THREE.ShaderMaterial({

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -21,7 +21,7 @@ function InteractiveLogo() {
       transition={{ type: "spring", stiffness: 80, damping: 10 }}
     >
       <motion.img
-        src="https://i.imgur.com/VHCRCEn.png"
+        src="/logo.png"
         alt="BLAiZE IT Logo"
         className="w-52 h-auto relative z-10 pointer-events-none"
         initial={{ scale: 0.85, opacity: 0 }}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -22,7 +22,7 @@ export default function Navbar() {
     >
       <div className="flex items-center max-w-7xl mx-auto px-4 py-2">
         <img
-          src="https://i.imgur.com/VHCRCEn.png"
+          src="/logo.png"
           alt="BLAiZE IT Logo"
           className="h-9 mr-3"
           draggable={false}


### PR DESCRIPTION
## Summary
- remove committed logo image and ignore local copy
- add script and package hooks to fetch logo asset during installation
- document install-time logo download in README

## Testing
- `npm test`
- `npm run build`
- `curl -I http://localhost:5174/logo.png`
- `curl -I http://localhost:4173/logo.png`


------
https://chatgpt.com/codex/tasks/task_e_6896cba068708323859d18eb2525db88